### PR TITLE
Bug unable to show plugins icon

### DIFF
--- a/app/views/layouts/_additional_header.html.erb
+++ b/app/views/layouts/_additional_header.html.erb
@@ -1,0 +1,1 @@
+<%= javascript_include_tag "application" %>

--- a/config/initializers/kaui.rb
+++ b/config/initializers/kaui.rb
@@ -44,6 +44,7 @@ Kaui.demo_mode ||= (ENV['KAUI_DEMO_MODE'] || 'false') == 'true'
 Kaui.plugins_whitelist ||= ENV.fetch('KAUI_PLUGINS_WHITELIST', nil)
 Kaui.root_username ||= (ENV['KAUI_ROOT_USERNAME'] || 'admin')
 Kaui.disable_sign_up_link ||= (ENV['KAUI_DISABLE_SIGN_UP_LINK'] || 'true') == 'true'
+Kaui.additional_headers_partial = 'layouts/additional_header'
 
 chargeback_reason_codes ||= ENV.fetch('KAUI_CHARGEBACK_REASON_CODES', nil)
 credit_reason_codes ||= ENV.fetch('KAUI_CREDIT_REASON_CODES', nil)


### PR DESCRIPTION
killbill-admin-standalone was unable to load the standalone.js after the Rails 7 upgrade.
Updates: 
+ Create a root view for killbill-admin-standalone and load the additional js files here.
+ Update Kaui layout config to use the root view.