### PR TITLE
Reject the origin jruby-rack.jar

### DIFF
--- a/config/warble.rb
+++ b/config/warble.rb
@@ -18,5 +18,9 @@ Warbler::Config.new do |config|
 
   config.webxml.jruby.rack.logging = 'slf4j'
 
+  # Remove this when the latest version of jruby-rack is released
+  # See this PR: https://github.com/killbill/killbill-admin-ui-standalone/pull/85
+  config.java_libs.reject! { |f| File.basename(f) =~ /^jruby-rack.*\.jar$/ }
+
   config.jar_name = 'killbill-admin-ui-standalone'
 end


### PR DESCRIPTION
Issue: https://github.com/killbill/killbill-admin-ui/issues/453
We have a custom jar file for jruby-rack.
This update makes sure the app will load the custom file, not the original.