### PR TITLE
Add purge_foreign_cookies.js to clear stale cross-subdomain cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,10 +49,7 @@ gem 'killbill-aviate'
 
 gem 'i18n'
 gem 'tzinfo-data'
-
-# This fix is temporary until the next release of the gem
-# See https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
-gem 'concurrent-ruby', '1.3.4'
+gem 'concurrent-ruby', '1.3.6'
 
 if defined?(JRUBY_VERSION)
   gem 'activerecord-jdbc-adapter', '~> 70.0', platforms: :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,42 +2,21 @@
 
 source 'https://rubygems.org'
 
+gem 'concurrent-ruby', '1.3.6'
+gem 'i18n'
 gem 'jquery-rails', '~> 4.5.1'
-gem 'mustache-js-rails', '~> 0.0.7'
-gem 'rails', '~> 7.0.1'
-gem 'sprockets-rails'
-
-# gem 'kaui'
-# gem 'kaui', path: '../killbill-admin-ui'
-gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'kaui_4.29'
 
 gem 'kanaui'
 # gem 'kanaui', :path => '../killbill-analytics-ui'
 # gem 'kanaui', github: 'killbill/killbill-analytics-ui', ref: 'master'
 
-gem 'killbill-avatax'
-# gem 'killbill-avatax', :path => '../killbill-avatax-ui'
-# gem 'killbill-avatax', github: 'killbill/killbill-avatax-ui', ref: 'master'
-
-gem 'killbill-kpm-ui'
-# gem 'killbill-kpm-ui', :path => '../killbill-kpm-ui'
-# gem 'killbill-kpm-ui', github: 'killbill/killbill-kpm-ui', ref: 'master'
-
-gem 'killbill-payment-test-ui'
-# gem 'killbill-payment-test-ui', :path => '../killbill-payment-test-ui'
-# gem 'killbill-payment-test-ui', github: 'killbill/killbill-payment-test-ui', ref: 'master'
+gem 'kaui'
+# gem 'kaui', path: '../killbill-admin-ui'
+# gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'master'
 
 gem 'kenui'
 # gem 'kenui', :path => '../killbill-email-notifications-ui'
 # gem 'kenui', github: 'killbill/killbill-email-notifications-ui', ref: 'master'
-
-gem 'killbill-deposit'
-# gem 'killbill-deposit', :path => '../killbill-deposit-ui'
-# gem 'killbill-deposit', github: 'killbill/killbill-deposit-ui', ref: 'main'
-
-gem 'killbill-client'
-# gem 'killbill-client', :path => '../killbill-client-ruby'
-# gem 'killbill-client', github: 'killbill/killbill-client-ruby', ref: 'master'
 
 # gem 'killbill-assets-ui', :path => '../killbill-assets-ui'
 # gem 'killbill-assets-ui', github: 'killbill/killbill-assets-ui', ref: 'main'
@@ -47,8 +26,29 @@ gem 'killbill-assets-ui'
 # gem 'killbill-aviate', github: 'killbill/killbill-aviate-ui', ref: 'main'
 gem 'killbill-aviate'
 
-gem 'i18n'
-gem 'concurrent-ruby', '1.3.6'
+gem 'killbill-avatax'
+# gem 'killbill-avatax', :path => '../killbill-avatax-ui'
+# gem 'killbill-avatax', github: 'killbill/killbill-avatax-ui', ref: 'master'
+
+gem 'killbill-client'
+# gem 'killbill-client', :path => '../killbill-client-ruby'
+# gem 'killbill-client', github: 'killbill/killbill-client-ruby', ref: 'master'
+
+gem 'killbill-deposit'
+# gem 'killbill-deposit', :path => '../killbill-deposit-ui'
+# gem 'killbill-deposit', github: 'killbill/killbill-deposit-ui', ref: 'main'
+
+gem 'killbill-kpm-ui'
+# gem 'killbill-kpm-ui', :path => '../killbill-kpm-ui'
+# gem 'killbill-kpm-ui', github: 'killbill/killbill-kpm-ui', ref: 'master'
+
+gem 'killbill-payment-test-ui'
+# gem 'killbill-payment-test-ui', :path => '../killbill-payment-test-ui'
+# gem 'killbill-payment-test-ui', github: 'killbill/killbill-payment-test-ui', ref: 'master'
+
+gem 'mustache-js-rails', '~> 0.0.7'
+gem 'rails', '~> 7.0.1'
+gem 'sprockets-rails'
 gem 'tzinfo-data'
 
 if defined?(JRUBY_VERSION)

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gem 'mustache-js-rails', '~> 0.0.7'
 gem 'rails', '~> 7.0.1'
 gem 'sprockets-rails'
 
-gem 'kaui'
+# gem 'kaui'
 # gem 'kaui', path: '../killbill-admin-ui'
-# gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'master'
+gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'kaui_4.29'
 
 gem 'kanaui'
 # gem 'kanaui', :path => '../killbill-analytics-ui'
@@ -48,8 +48,8 @@ gem 'killbill-assets-ui'
 gem 'killbill-aviate'
 
 gem 'i18n'
-gem 'tzinfo-data'
 gem 'concurrent-ruby', '1.3.6'
+gem 'tzinfo-data'
 
 if defined?(JRUBY_VERSION)
   gem 'activerecord-jdbc-adapter', '~> 70.0', platforms: :jruby

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,9 @@
 // WARNING: THE FIRST BLANK LINE MARKS THE END OF WHAT'S TO BE PROCESSED, ANY BLANK LINE SHOULD
 // GO AFTER THE REQUIRES BELOW.
 //
+// Purge stale cross-subdomain cookies (e.g. leftover aviate cookies)
+//= require purge_foreign_cookies
+//
 // Common (order matters)
 //= require assets/common
 //= require d3

--- a/app/assets/javascripts/purge_foreign_cookies.js
+++ b/app/assets/javascripts/purge_foreign_cookies.js
@@ -1,0 +1,47 @@
+(function () {
+  // Prefixes of cookies that belong to this app (kaui).
+  // Any cookie whose name does NOT start with one of these will be deleted.
+  var KNOWN_PREFIXES = [
+    '_kaui',
+    'remember_user_token',
+    '_csrf',
+    'authenticity_token',
+    'jwt_token',
+    'avt_'
+  ];
+
+  // Optional: parent domain to also target when deleting broad-scoped cookies
+  // (e.g. cookies originally set with domain=.killbill.io).
+  // Set window.KAUI_PARENT_DOMAIN from your ERB layout if needed:
+  //   <script>window.KAUI_PARENT_DOMAIN = "<%= ENV['KAUI_PARENT_DOMAIN'] %>";</script>
+  var parentDomain = window.KAUI_PARENT_DOMAIN || null;
+
+  function isKnown(name) {
+    return KNOWN_PREFIXES.some(function (prefix) {
+      return name.indexOf(prefix) === 0;
+    });
+  }
+
+  function expireCookie(name, domain) {
+    var base = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    document.cookie = domain ? base + '; domain=' + domain : base;
+  }
+
+  function purgeForeignCookies() {
+    var cookies = document.cookie.split(';');
+    cookies.forEach(function (c) {
+      var name = c.trim().split('=')[0];
+      if (name && !isKnown(name)) {
+        expireCookie(name);                      // bare host scope
+        if (parentDomain) {
+          expireCookie(name, parentDomain);      // broad .killbill.io scope
+        }
+      }
+    });
+  }
+
+  var LOGIN_PATH = '/users/sign_in';
+  if (window.location.pathname === LOGIN_PATH) {
+    purgeForeignCookies();
+  }
+})();


### PR DESCRIPTION
Related issues:
- https://github.com/killbill/killbill-admin-ui/issues/591: The login page will force clean all the unknown cookies