### PR TITLE
Link aviate_manifest.js for Aviate usage page assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,9 @@ gem 'kanaui'
 # gem 'kanaui', :path => '../killbill-analytics-ui'
 # gem 'kanaui', github: 'killbill/killbill-analytics-ui', ref: 'master'
 
-gem 'kaui'
+# gem 'kaui'
 # gem 'kaui', path: '../killbill-admin-ui'
-# gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'master'
+gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'kaui_7.28'
 
 gem 'kenui'
 # gem 'kenui', :path => '../killbill-email-notifications-ui'
@@ -25,7 +25,7 @@ gem 'killbill-assets-ui'
 
 # gem 'killbill-aviate', :path => '../killbill-aviate-ui'
 # gem 'killbill-aviate', github: 'killbill/killbill-aviate-ui', ref: 'main'
-gem 'killbill-aviate'
+gem 'killbill-aviate', '2.4.0.pre.1'
 
 gem 'killbill-avatax'
 # gem 'killbill-avatax', :path => '../killbill-avatax-ui'

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -17,6 +17,7 @@
 //= link kaui/kaui.css
 //= link kaui/logo.svg
 //= link avatax_manifest.js
+//= link aviate_manifest.js
 //= link kanaui/kanaui.css
 // Kaui (needs to be loaded last for overrides)
 //= link kaui/kaui.js


### PR DESCRIPTION
## Summary
Fixes an asset precompile error for the Aviate metering/usage screens: `Asset aviate_application.js was not declared to be precompiled`.

killbill-aviate-ui ships its own `aviate_manifest.js` (linking `aviate_application.js` and its JS/CSS dependencies), but it was never referenced from this app's `app/assets/config/manifest.js`, unlike the existing `avatax_manifest.js` link. One-line fix: link it.

## Related
- killbill/technical-support#206
- Companion PRs: killbill-admin-ui (Usage nav entry points), killbill-aviate-ui (usage feature + bug fixes)