### PR TITLE
Disable jruby-rack response dechunking to fix Rack 3 boot failure

### DIFF
--- a/config/warble.rb
+++ b/config/warble.rb
@@ -17,5 +17,9 @@ Warbler::Config.new do |config|
 
   config.webxml.jruby.rack.logging = 'slf4j'
 
+  # Rack::Chunked was removed in Rack 3 (Rails 7.2), so disable jruby-rack's
+  # dechunking boot hook, which otherwise fails to `require 'rack/chunked'`.
+  config.webxml.jruby.rack.response.dechunk = 'false'
+
   config.jar_name = 'killbill-admin-ui-standalone'
 end


### PR DESCRIPTION
## Summary
- After deploying the Rails 7.2 / Rack 3 upgrade, the app fails to boot with `LoadError: cannot load such file -- rack/chunked`.
- `Rack::Chunked` was removed entirely in Rack 3, but `jruby-rack`'s default `response.dechunk = patch` boot hook unconditionally does `require 'rack/chunked'` to monkey-patch it. Bumping `jruby-rack` to 1.3.0 doesn't help — the same unconditional require exists there — and 2.0 requires Jakarta Servlet 5 / Tomcat 10+, incompatible with this app's Tomcat 9 deployment (see `config/warble.rb`).
- Disable the dechunking boot hook via the `jruby.rack.response.dechunk` web.xml context-param. This is behaviorally a no-op: Rack no longer produces chunk-framed response bodies for jruby-rack to dechunk in the first place.

## Test plan
- [ ] Rebuild the war (`mvn package` / `build.sh`) and redeploy — confirm the app boots without the `rack/chunked` LoadError.
- [ ] Smoke test a streamed/large response to confirm no double-chunking regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)