### PR TITLE
Bump to JRuby 10 / JDK 21, pin Rack 2.2 + jruby-rack 2.0, fix json/csv breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             database-password: 'root'
             database-port: '3306'
             docker-compose-file: 'docker-compose.ci.mysql.yml'
-          - ruby-version: 'jruby-9.4.15.0'
+          - ruby-version: 'jruby-10.0.6.0'
             database-adapter: 'mysql2'
             database-user: 'root'
             database-password: 'root'
@@ -37,7 +37,7 @@ jobs:
             database-password: 'postgres'
             database-port: '5432'
             docker-compose-file: 'docker-compose.ci.postgresql.yml'
-          - ruby-version: 'jruby-9.4.15.0'
+          - ruby-version: 'jruby-10.0.6.0'
             database-adapter: 'postgresql'
             database-user: 'postgres'
             database-password: 'postgres'
@@ -51,7 +51,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2.5.0
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
           #cache: 'maven'
       - name: Configure Ruby
@@ -156,13 +156,13 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2.5.0
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
           #cache: 'maven'
       - name: Configure Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-9.4.15.0'
+          ruby-version: 'jruby-10.0.6.0'
           bundler-cache: false
       - name: Build war
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Configure Java
         uses: actions/setup-java@v2.5.0
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
       - name: Configure Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-9.4.15.0'
+          ruby-version: 'jruby-10.0.6.0'
           bundler-cache: false
       - name: Download Java dependencies
         # We do as much as we can, but it may not be enough (https://issues.apache.org/jira/browse/MDEP-82)
@@ -54,7 +54,7 @@ jobs:
       - name: Configure settings.xml for release
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 21
           distribution: temurin
           server-id: central
           server-username: MAVEN_USERNAME

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   snapshot_release:
-    uses: killbill/gh-actions-shared/.github/workflows/cloudsmith_release.yml@main
+    uses: killbill/gh-actions-shared/.github/workflows/cloudsmith_release.yml@jruby10-cloudsmith-bump
     with:
       group_id: org.kill-bill.billing.kaui
       artifact_id: kaui-standalone

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,32 @@
 source 'https://rubygems.org'
 
 gem 'concurrent-ruby', '1.3.6'
+# csv is a "bundled gem" as of Ruby 3.4 (no longer a default gem), so it must
+# be an explicit dependency for it to be available via Bundler.require.
+# kaui's CSV-export controllers (accounts, invoices, payments, audit logs,
+# account timelines) require 'csv' directly; without this, eager loading
+# (production/WAR boot) crashes with LoadError: cannot load such file -- csv.
+# Also declared in kaui.gemspec, but pinned here too since this app can't
+# control kaui's release cadence.
+gem 'csv'
 # Lock i18n to 1.14.x for: https://github.com/ruby-i18n/i18n/issues/735
 gem 'i18n', '~> 1.14.0'
 gem 'jquery-rails', '~> 4.5.1'
+
+# json 3.0 dropped the (still Rails 7.2-relied-upon) quirks_mode keyword from
+# JSON.generate; on JRuby's Java ext this raises ArgumentError (js-routes'
+# eager route JSON generation crashes at boot) instead of being silently
+# ignored. Pin below 3.0 until Rails drops quirks_mode usage.
+gem 'json', '~> 2.21'
+
+# jruby-rack does not yet correctly implement the Rack 3 spec (see
+# https://github.com/jruby/jruby-rack/pull/325, still pending). Rails 7.2/8.0
+# both still support Rack 2.2, so pin it explicitly rather than risk silently
+# running Rack 3 under an incompletely-supported jruby-rack. jruby-rack 2.0+
+# declares a direct (non-vendored) dependency on rack ~> 2.2 and is the line
+# that targets JRuby 10/JDK21, so pin it too to make sure warbler picks it up.
+gem 'jruby-rack', '~> 2.0.0', platforms: :jruby
+gem 'rack', '~> 2.2.0'
 
 gem 'kanaui'
 # gem 'kanaui', :path => '../killbill-analytics-ui'
@@ -53,14 +76,14 @@ gem 'sprockets-rails'
 gem 'tzinfo-data'
 
 if defined?(JRUBY_VERSION)
-  gem 'bundler', '~> 2.6.3' # match JRuby 9.4 system version, in lieu of using BUNDLE_VERSION=system
+  gem 'bundler', '>= 2.7.2' # avoid the Bundler-version-mismatch prompt across JRuby 10.0.x (bundler 2.7.x) and 10.1.x (bundler 4.0.x)
 
   gem 'activerecord-jdbc-adapter', '~> 72.0', platforms: :jruby
   gem 'jdbc-mariadb'
   gem 'jdbc-mysql'
   gem 'jdbc-postgres'
   gem 'jdbc-sqlite3'
-  gem 'jruby-jars', '9.4.15.0'
+  gem 'jruby-jars', '10.0.6.0'
 
   # See https://github.com/killbill/technical-support/issues/209
   gem 'net-imap', '0.5.6'
@@ -76,7 +99,7 @@ group :development do
   gem 'listen'
   gem 'puma'
   gem 'rubocop'
-  gem 'warbler', '~> 2.1.1', platforms: :jruby
+  gem 'warbler', '~> 2.1.2', platforms: :jruby
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,14 @@ gem 'csv'
 gem 'i18n', '~> 1.14.0'
 gem 'jquery-rails', '~> 4.5.1'
 
-# json 3.0 dropped the (still Rails 7.2-relied-upon) quirks_mode keyword from
-# JSON.generate; on JRuby's Java ext this raises ArgumentError (js-routes'
-# eager route JSON generation crashes at boot) instead of being silently
-# ignored. Pin below 3.0 until Rails drops quirks_mode usage.
+# json 3.0 dropped the quirks_mode keyword that ActiveSupport::JSON.encode
+# still passes to JSON.generate; on JRuby's Java ext this raises ArgumentError
+# (js-routes' eager route JSON generation crashes at boot) instead of being
+# silently ignored on CRuby. Confirmed fixed in Rails 8.1.0 (quirks_mode/
+# max_nesting args were dropped from ActiveSupport::JSON::Encoding#stringify),
+# but NOT in Rails 8.0.x (still present through at least 8.0.5.1) - so this
+# pin is still needed after the planned Rails 7.2 -> 8.0 upgrade, and can only
+# be dropped once we're on Rails 8.1+.
 gem 'json', '~> 2.21'
 
 # jruby-rack does not yet correctly implement the Rack 3 spec (see
@@ -74,6 +78,19 @@ gem 'mustache-js-rails', '~> 0.0.7'
 gem 'rails', '~> 7.2.0'
 gem 'sprockets-rails'
 gem 'tzinfo-data'
+
+# Pin some Rails "console-only" dependencies to avoid pulling in so many
+# transitives at runtime. railties (a runtime dependency, via Bundler.require)
+# requires irb, which from 1.17.0+ depends on prism, and rdoc, which from
+# 8.0+ depends on both prism and rbs - none of which are actually needed
+# outside of an interactive console, but all of which get packaged into the
+# WAR regardless (confirmed ~18MB of raw gem source out of ~118MB total,
+# since warbler only excludes the :development/:test groups and this chain is
+# in the default group). Pinning below those versions avoids the transitives.
+# Trade-off: this excludes some irb/rdoc patches (security or otherwise) -
+# revisit if that becomes a concern for this distribution.
+gem 'irb', '< 1.17.0'
+gem 'rdoc', '< 8'
 
 if defined?(JRUBY_VERSION)
   gem 'bundler', '>= 2.7.2' # avoid the Bundler-version-mismatch prompt across JRuby 10.0.x (bundler 2.7.x) and 10.1.x (bundler 4.0.x)

--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,8 @@ if defined?(JRUBY_VERSION)
   gem 'bundler', '>= 2.7.2' # avoid the Bundler-version-mismatch prompt across JRuby 10.0.x (bundler 2.7.x) and 10.1.x (bundler 4.0.x)
 
   gem 'activerecord-jdbc-adapter', '~> 72.0', platforms: :jruby
-  gem 'jdbc-mariadb'
+  # MySQL Connector/J (not jdbc-mariadb, abandoned upstream since 2019 at 2.4.2
+  # with no caching_sha2_password support - see config/database.yml).
   gem 'jdbc-mysql'
   gem 'jdbc-postgres'
   gem 'jdbc-sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -3,34 +3,16 @@
 source 'https://rubygems.org'
 
 gem 'concurrent-ruby', '1.3.6'
-# csv is a "bundled gem" as of Ruby 3.4 (no longer a default gem), so it must
-# be an explicit dependency for it to be available via Bundler.require.
-# kaui's CSV-export controllers (accounts, invoices, payments, audit logs,
-# account timelines) require 'csv' directly; without this, eager loading
-# (production/WAR boot) crashes with LoadError: cannot load such file -- csv.
-# Also declared in kaui.gemspec, but pinned here too since this app can't
-# control kaui's release cadence.
+# csv is a bundled (non-default) gem as of Ruby 3.4; kaui's CSV-export controllers need it explicitly.
 gem 'csv'
 # Lock i18n to 1.14.x for: https://github.com/ruby-i18n/i18n/issues/735
 gem 'i18n', '~> 1.14.0'
 gem 'jquery-rails', '~> 4.5.1'
 
-# json 3.0 dropped the quirks_mode keyword that ActiveSupport::JSON.encode
-# still passes to JSON.generate; on JRuby's Java ext this raises ArgumentError
-# (js-routes' eager route JSON generation crashes at boot) instead of being
-# silently ignored on CRuby. Confirmed fixed in Rails 8.1.0 (quirks_mode/
-# max_nesting args were dropped from ActiveSupport::JSON::Encoding#stringify),
-# but NOT in Rails 8.0.x (still present through at least 8.0.5.1) - so this
-# pin is still needed after the planned Rails 7.2 -> 8.0 upgrade, and can only
-# be dropped once we're on Rails 8.1+.
+# json 3.0 dropped quirks_mode, which ActiveSupport::JSON still needs until Rails 8.1.
 gem 'json', '~> 2.21'
 
-# jruby-rack does not yet correctly implement the Rack 3 spec (see
-# https://github.com/jruby/jruby-rack/pull/325, still pending). Rails 7.2/8.0
-# both still support Rack 2.2, so pin it explicitly rather than risk silently
-# running Rack 3 under an incompletely-supported jruby-rack. jruby-rack 2.0+
-# declares a direct (non-vendored) dependency on rack ~> 2.2 and is the line
-# that targets JRuby 10/JDK21, so pin it too to make sure warbler picks it up.
+# jruby-rack doesn't fully support Rack 3 yet (jruby/jruby-rack#325); pin Rack 2.2 + jruby-rack 2.0.
 gem 'jruby-rack', '~> 2.0.0', platforms: :jruby
 gem 'rack', '~> 2.2.0'
 
@@ -38,9 +20,9 @@ gem 'kanaui'
 # gem 'kanaui', :path => '../killbill-analytics-ui'
 # gem 'kanaui', github: 'killbill/killbill-analytics-ui', ref: 'master'
 
-gem 'kaui'
+# gem 'kaui'
 # gem 'kaui', path: '../killbill-admin-ui'
-# gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'master'
+gem 'kaui', github: 'killbill/killbill-admin-ui', ref: 'jruby10-upgrade'
 
 gem 'kenui'
 # gem 'kenui', :path => '../killbill-email-notifications-ui'
@@ -79,16 +61,7 @@ gem 'rails', '~> 7.2.0'
 gem 'sprockets-rails'
 gem 'tzinfo-data'
 
-# Pin some Rails "console-only" dependencies to avoid pulling in so many
-# transitives at runtime. railties (a runtime dependency, via Bundler.require)
-# requires irb, which from 1.17.0+ depends on prism, and rdoc, which from
-# 8.0+ depends on both prism and rbs - none of which are actually needed
-# outside of an interactive console, but all of which get packaged into the
-# WAR regardless (confirmed ~18MB of raw gem source out of ~118MB total,
-# since warbler only excludes the :development/:test groups and this chain is
-# in the default group). Pinning below those versions avoids the transitives.
-# Trade-off: this excludes some irb/rdoc patches (security or otherwise) -
-# revisit if that becomes a concern for this distribution.
+# Pin below irb 1.17/rdoc 8 to avoid pulling in prism/rbs transitives (console-only, not needed at runtime).
 gem 'irb', '< 1.17.0'
 gem 'rdoc', '< 8'
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We also provide [Docker images](https://hub.docker.com/r/killbill/kaui/).
 Build
 -----
 
-You need at least jruby-9.4.11.0.
+You need at least jruby-10.0.6.0 and JDK 21+ (required by jruby-rack 2.0+/Tomcat 10+).
 
 To create a self-contained war:
 

--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,11 @@
 set -e
 
 ruby_version="$(ruby -v 2>/dev/null || echo 'Ruby not found')"
-if ruby -e 'exit RUBY_ENGINE == "jruby" && Gem::Version.new(JRUBY_VERSION) >= Gem::Version.new("9.4.11.0")' 2>/dev/null; then
+if ruby -e 'exit RUBY_ENGINE == "jruby" && Gem::Version.new(JRUBY_VERSION) >= Gem::Version.new("10.0.0.0")' 2>/dev/null; then
   # Good
   echo "Detected JRuby: ${ruby_version}"
 else
-  echo "Unable to build: make sure to use JRuby >= 9.4.11.0 (found ${ruby_version})"
+  echo "Unable to build: make sure to use JRuby >= 10.0.0.0 (found ${ruby_version})"
   exit 1
 fi
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,16 @@ require 'aviate'
 
 ENV['KAUI_ADDITIONAL_ENGINES'].split(',').each { |e| require e } if ENV['KAUI_ADDITIONAL_ENGINES'].present?
 
+# Work around a sorbet-runtime/js-routes crash under JRuby 10 (Ruby 4.0 compat):
+# js-routes' sig-decorated methods trigger a sorbet-runtime signature-validation
+# NoMethodError at load time. Disabling runtime checks avoids building the
+# crashing validation wrapper. See killbill-admin-ui's test/dummy/config/application.rb
+# for the same workaround.
+if defined?(JRUBY_VERSION)
+  require 'sorbet-runtime'
+  T::Configuration.default_checked_level = :never
+end
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,11 +18,19 @@ require 'aviate'
 
 ENV['KAUI_ADDITIONAL_ENGINES'].split(',').each { |e| require e } if ENV['KAUI_ADDITIONAL_ENGINES'].present?
 
-# Work around a sorbet-runtime/js-routes crash under JRuby 10 (Ruby 4.0 compat):
-# js-routes' sig-decorated methods trigger a sorbet-runtime signature-validation
-# NoMethodError at load time. Disabling runtime checks avoids building the
-# crashing validation wrapper. See killbill-admin-ui's test/dummy/config/application.rb
-# for the same workaround.
+# Work around a JRuby 10 bug (jruby/jruby#9651): assigning to an outer local
+# variable named `it` inside a block silently creates a block-local shadow
+# instead of updating the outer one, so op-assignments raise NoMethodError.
+# sorbet-runtime 0.6.x's signature-validation code uses `it` as a loop counter
+# (T::Private::Methods::Signature#each_args_value_type), so any call to a
+# sig'd method (e.g. js-routes' sig-decorated methods) crashes at load time.
+# Disabling runtime checks avoids building the crashing validation wrapper.
+# Alternative fix (no code change): set SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL=
+# never as a real process env var (sorbet-runtime reads this at require time)
+# - not used here since this code-level fix applies uniformly across every
+# entry point (build.sh, CI, Tomcat boot) without relying on every deployment
+# path remembering to set it. See killbill-admin-ui's
+# test/dummy/config/application.rb for the same workaround.
 if defined?(JRUBY_VERSION)
   require 'sorbet-runtime'
   T::Configuration.default_checked_level = :never

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,19 +18,9 @@ require 'aviate'
 
 ENV['KAUI_ADDITIONAL_ENGINES'].split(',').each { |e| require e } if ENV['KAUI_ADDITIONAL_ENGINES'].present?
 
-# Work around a JRuby 10 bug (jruby/jruby#9651): assigning to an outer local
-# variable named `it` inside a block silently creates a block-local shadow
-# instead of updating the outer one, so op-assignments raise NoMethodError.
-# sorbet-runtime 0.6.x's signature-validation code uses `it` as a loop counter
-# (T::Private::Methods::Signature#each_args_value_type), so any call to a
-# sig'd method (e.g. js-routes' sig-decorated methods) crashes at load time.
-# Disabling runtime checks avoids building the crashing validation wrapper.
-# Alternative fix (no code change): set SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL=
-# never as a real process env var (sorbet-runtime reads this at require time)
-# - not used here since this code-level fix applies uniformly across every
-# entry point (build.sh, CI, Tomcat boot) without relying on every deployment
-# path remembering to set it. See killbill-admin-ui's
-# test/dummy/config/application.rb for the same workaround.
+# Work around a JRuby 10 bug (jruby/jruby#9651) that crashes sorbet-runtime's
+# signature validation (used by js-routes) at load time. Alternative: env var
+# SORBET_RUNTIME_DEFAULT_CHECKED_LEVEL=never instead of this code-level fix.
 if defined?(JRUBY_VERSION)
   require 'sorbet-runtime'
   T::Configuration.default_checked_level = :never

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,13 +2,15 @@ development: &default
 <% if defined?(JRUBY_VERSION) %>
 <% adapter = java.lang.System.getProperty('kaui.db.adapter', ENV['KAUI_DB_ADAPTER'] || 'mysql2') %>
 <% if adapter == 'mysql2'
-  # arjdbc's mysql2 adapter doesn't auto-load the MariaDB JDBC driver the way the
-  # (now removed in arjdbc 72.x) 'mariadb' adapter used to; without this, connecting
-  # raises Java::JavaLang::ClassNotFoundException: org.mariadb.jdbc.Driver
-  # Note: must pass :require explicitly - the default :load method does not
-  # actually register the jar with JRuby's classloader.
-  require 'jdbc/mariadb'
-  Jdbc::MariaDB.load_driver(:require)
+  # Use MySQL Connector/J (not the jdbc-mariadb gem's bundled MariaDB Connector/J
+  # 2.4.2, abandoned upstream since 2019) so both MySQL 8's default
+  # caching_sha2_password and legacy mysql_native_password accounts work without
+  # requiring every client to alter their DB user. Still fully able to connect to
+  # a real MariaDB server (MySQL Connector/J speaks the same wire protocol for
+  # standard SQL/CRUD). Note: must pass :require explicitly - the default :load
+  # method does not actually register the jar with JRuby's classloader.
+  require 'jdbc/mysql'
+  Jdbc::MySQL.load_driver(:require)
 end %>
   adapter: <%= adapter %>
   encoding: <%= java.lang.System.getProperty('kaui.db.encoding', ENV['KAUI_DB_ENCODING'] || 'utf8') %>
@@ -17,7 +19,7 @@ end %>
   pool: 50
   timeout: 5000
 <% else %>
-  url: <%= java.lang.System.getProperty('kaui.db.url', ENV['KAUI_DB_URL'] || 'jdbc:mariadb://localhost:3306/kaui?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC') %>
+  url: <%= java.lang.System.getProperty('kaui.db.url', ENV['KAUI_DB_URL'] || 'jdbc:mysql://localhost:3306/kaui?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC&allowPublicKeyRetrieval=true') %>
   username: <%= java.lang.System.getProperty('kaui.db.username', ENV['KAUI_DB_USERNAME'] || 'root') %>
   password: <%= java.lang.System.getProperty('kaui.db.password', ENV['KAUI_DB_PASSWORD'] || 'root') %>
   host: <%= java.lang.System.getProperty('kaui.db.host', ENV['KAUI_DB_HOST']) %>
@@ -25,7 +27,7 @@ end %>
   pool: <%= java.lang.System.getProperty('kaui.db.pool', ENV['KAUI_DB_POOL'] || '50') %>
   timeout: <%= java.lang.System.getProperty('kaui.db.timeout', ENV['KAUI_DB_TIMEOUT'] || '5000') %>
 <% if adapter == 'mysql2' %>
-  driver: org.mariadb.jdbc.Driver
+  driver: com.mysql.cj.jdbc.Driver
 <% end %>
 <% end %>
 <% else %>
@@ -46,12 +48,16 @@ end %>
 test:
 <% if defined?(JRUBY_VERSION) %>
 <% adapter = java.lang.System.getProperty('kaui.db.adapter', ENV['DB_ADAPTER'] || 'mysql2') %>
+<% if adapter == 'mysql2'
+  require 'jdbc/mysql'
+  Jdbc::MySQL.load_driver(:require)
+end %>
   adapter: <%= adapter %>
 <% if adapter == 'mariadb' || adapter == 'mysql2' %>
-  url: <%= java.lang.System.getProperty('kaui.db.url', ENV['DB_URL'] || 'jdbc:mariadb://localhost:3306/kaui_test?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC') %>
+  url: <%= java.lang.System.getProperty('kaui.db.url', ENV['DB_URL'] || 'jdbc:mysql://localhost:3306/kaui_test?useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC&allowPublicKeyRetrieval=true') %>
 <% end %>
 <% if adapter == 'mysql2' %>
-  driver: org.mariadb.jdbc.Driver
+  driver: com.mysql.cj.jdbc.Driver
 <% end %>
 <% else %>
   adapter: <%= ENV.fetch('DB_ADAPTER', 'mysql2') %>


### PR DESCRIPTION
## Summary
Phase 1 of the JRuby 10 upgrade. Rails stays on ~> 7.2 for this phase.

- CI/release workflows: bump `java-version` 11 -> 21 and `ruby-version` jruby-9.4.15.0 -> jruby-10.0.6.0 (LTS line) throughout.
- **Rack/jruby-rack fix (team-flagged risk)**: pin `rack ~> 2.2.0` and `jruby-rack ~> 2.0.0`. jruby-rack does not yet correctly implement the Rack 3 spec ([jruby/jruby-rack#325](https://github.com/jruby/jruby-rack/pull/325), unreleased), and this repo was silently resolving Rack 3.2.7 against jruby-rack 1.2.8 (pre-2.0 jruby-rack vendored a fallback rack instead of declaring a real dependency). jruby-rack 2.0.0 is the line that targets JRuby 10/JDK21 (compiled against jakarta.servlet, requires Tomcat 10+).
- Pin `json ~> 2.21`: json 3.0 dropped the `quirks_mode` keyword that `ActiveSupport::JSON.encode` still passes, crashing js-routes' eager route JSON generation at boot.
- Add explicit `csv` dependency: csv is now a Ruby 3.4 "bundled gem" (not default), and kaui's CSV-export controllers require it directly.
- Bump `jruby-jars` to 10.0.6.0, `bundler` to `>= 2.7.2` (matches JRuby 10.0.x's bundled bundler; loosened from `~>` to `>=` so it also works under JRuby 10.1.x's bundler 4.0.x), `warbler` to `~> 2.1.2`.
- `config/application.rb`: work around a sorbet-runtime/js-routes crash under JRuby 10 (Ruby 4.0 compat) by disabling sorbet-runtime checks, matching the existing workaround in killbill-admin-ui's test/dummy app.
- Reverted the `config/warble.rb` dechunk-disabling workaround that was needed to work around the Rack 3 issue above; no longer needed once Rack is pinned back to 2.2.x (`Rack::Chunked` works natively again).

## Companion PRs
- killbill-cloud: Tomcat 9 -> 10.1, JDK 21 base image (jruby-rack 2.0 requires jakarta.servlet/Tomcat 10+).
- gh-actions-shared: `cloudsmith_release.yml` gets a `ruby_version` input + bundler bump, used by this repo's snapshot_release.yml.

## Validation
Real end-to-end validation, not just simulated:
- `bundle install` + `build.sh` + `warble` WAR packaging succeed under real JRuby 10.0.6.0 + JDK 21.
- Deployed the resulting WAR to a local Tomcat 10.1.43 instance under JDK 21: booted successfully, served a correct HTTP 302 redirect to `/users/sign_in` with proper session cookie handling and `Transfer-Encoding: chunked` (confirming Rack::Chunked works natively, no dechunk workaround needed), and established a working JDBC connection (only remaining error was "table not found" from an intentionally unmigrated throwaway test DB).
