### PR TITLE
Pin json gem to ~> 2.21 to fix release build crash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,12 @@ gem 'concurrent-ruby', '1.3.6'
 gem 'i18n', '~> 1.14.0'
 gem 'jquery-rails', '~> 4.5.1'
 
+# json 3.0 dropped the quirks_mode keyword that ActiveSupport::JSON.encode
+# still passes to JSON.generate; this raises ArgumentError instead of being
+# silently ignored, crashing js-routes' eager route JSON generation at boot.
+# Pin to the 2.x line until Rails drops that keyword (fixed in Rails 8.1.0).
+gem 'json', '~> 2.21'
+
 gem 'kanaui'
 # gem 'kanaui', :path => '../killbill-analytics-ui'
 # gem 'kanaui', github: 'killbill/killbill-analytics-ui', ref: 'master'


### PR DESCRIPTION
## Problem
The [release run #34320880455](https://github.com/killbill/killbill-admin-ui-standalone/actions/runs/34320880455) failed in the "Download Java dependencies" step, which invokes `build.sh` -> `bundle install` -> `bin/rails assets:clobber ...`:

```
bin/rails aborted!
ArgumentError: unknown keyword: quirks_mode
config/environment.rb:7:in `<main>'
```

## Root cause
- `Gemfile` has no pin on the `json` gem and there is no committed `Gemfile.lock`, so every `bundle install` re-resolves the latest compatible `json` version.
- The `json` gem released **3.0.0 today** (2026-09-09). Starting with 3.0, unknown keyword options (e.g. typos) now raise `ArgumentError` instead of being silently ignored.
- Rails 7.2.3.2's `ActiveSupport::JSON::Encoding::JSONGemEncoder#stringify` still calls `JSON.generate(jsonified, quirks_mode: true, max_nesting: false)`, passing the now-rejected `quirks_mode` keyword.
- At Rails boot, `js-routes` eagerly generates its routes JSON, hits this incompatibility, and crashes boot, which aborts `build.sh` and fails the release build.

## Fix
Pin `gem 'json', '~> 2.21'` in the Gemfile so `bundle install` never resolves `json` 3.x until Rails drops the `quirks_mode` keyword (fixed upstream in Rails 8.1.0).

## Validation
Reproduced and fixed locally with jruby-9.4.15.0 (matching this repo's current release workflow):
- Before the fix: `bundle install` resolves `json 3.0.2`; `bin/rails runner` aborts with `ArgumentError: unknown keyword: quirks_mode`.
- After the fix: `bundle install` resolves `json 2.21.2`; `RAILS_ENV=production bin/rails runner "puts 'RAILS BOOTED OK'"` boots successfully.

## Scope note
This is a minimal, targeted fix for the release-breaking regression only. It does not include the broader JRuby 10 / Rack 3 / JDK 21 upgrade work tracked separately in #122.